### PR TITLE
Fix home page animations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -193,7 +193,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    print("building main");
     themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
     hapticNotifier = Provider.of<HapticNotifier>(context, listen: false);
     soundNotifier = Provider.of<SoundNotifer>(context, listen: false);
@@ -223,7 +222,7 @@ class _MyHomePageState extends State<MyHomePage> {
         valueListenable: _navBarHeight,
         builder: (context, value, child) {
           return AnimatedContainer(
-            duration: Duration(milliseconds: 100), // Smoother animation
+            duration: Duration(milliseconds: 10), // Smoother animation
             height: value,
             child: CustomNavBar(
               currentIndex: _navBarIndex.value,
@@ -231,7 +230,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 if (index == 0 || index == 3) {
                   // Navigation logic
                 } else {
-                  _pageController.jumpToPage(index - 1);
+                  _pageController.animateToPage(index - 1,
+                      duration: Duration(milliseconds: 750),
+                      curve: Curves.ease);
                 }
               },
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:page_transition/page_transition.dart';
 import 'package:provider/provider.dart';
 import 'package:dimensions_theme/dimensions_theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -227,17 +228,27 @@ class _MyHomePageState extends State<MyHomePage> {
             child: CustomNavBar(
               currentIndex: _navBarIndex.value,
               onTap: (index) {
-                if (index == 0 || index == 3) {
+                if (index == 0) {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(
-                        builder: (context) => index == 0
-                            ? StatsPage(service: widget.service)
-                            : SettingsPage(
-                                service: widget.service,
-                                themeNotifier: themeNotifier,
-                                hapticNotifier: hapticNotifier,
-                                soundNotifier: soundNotifier)),
+                    PageTransition(
+                        type: PageTransitionType.leftToRight,
+                        child: StatsPage(service: widget.service),
+                        isIos: true,
+                        curve: Curves.ease),
+                  );
+                } else if (index == 3) {
+                  Navigator.push(
+                    context,
+                    PageTransition(
+                        type: PageTransitionType.rightToLeft,
+                        child: SettingsPage(
+                            service: widget.service,
+                            themeNotifier: themeNotifier,
+                            hapticNotifier: hapticNotifier,
+                            soundNotifier: soundNotifier),
+                        isIos: true,
+                        curve: Curves.ease),
                   );
                 } else {
                   _pageController.animateToPage(index - 1,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,7 +155,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _navBarIndex = 1;
+  ValueNotifier<int> _navBarIndex = ValueNotifier<int>(1);
   late PageController _pageController;
   late ThemeNotifier themeNotifier;
   late HapticNotifier hapticNotifier;
@@ -169,8 +169,8 @@ class _MyHomePageState extends State<MyHomePage> {
     widget.service.initalizeHapticSetting();
     widget.service.initalizeSoundSetting();
 
-    _pageController =
-        PageController(initialPage: _navBarIndex - 1); // Adjust the initialPage
+    _pageController = PageController(
+        initialPage: _navBarIndex.value - 1); // Adjust the initialPage
     themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
     hapticNotifier = Provider.of<HapticNotifier>(context, listen: false);
     soundNotifier = Provider.of<SoundNotifer>(context, listen: false);
@@ -188,6 +188,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    print("building main");
     themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
     hapticNotifier = Provider.of<HapticNotifier>(context, listen: false);
     soundNotifier = Provider.of<SoundNotifer>(context, listen: false);
@@ -204,44 +205,37 @@ class _MyHomePageState extends State<MyHomePage> {
         ),
       ),
     ];
+
     return Scaffold(
-        body: PageView(
-          controller: _pageController,
-          onPageChanged: (index) {
-            setState(() {
-              _navBarIndex = index + 1;
-            });
-          },
-          children: pages,
-        ),
-        bottomNavigationBar: AnimatedContainer(
-          duration: Duration(milliseconds: 300),
-          height: _navBarIndex == 1
-              ? 84.0
-              : 0, // assuming 60.0 is the height of your nav bar
-          child: (_navBarIndex == 1)
-              ? CustomNavBar(
-                  currentIndex: _navBarIndex,
-                  onTap: (index) {
-                    if (index == 0 || index == 3) {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => index == 0
-                                ? StatsPage(service: widget.service)
-                                : SettingsPage(
-                                    service: widget.service,
-                                    themeNotifier: themeNotifier,
-                                    hapticNotifier: hapticNotifier,
-                                    soundNotifier: soundNotifier)),
-                      );
-                    } else {
-                      _pageController.jumpToPage(index - 1);
-                    }
-                  },
-                )
-              : null,
-        ));
+      body: PageView(
+        controller: _pageController,
+        onPageChanged: (index) {
+          _navBarIndex.value = index + 1;
+        },
+        children: pages,
+      ),
+      bottomNavigationBar: ValueListenableBuilder<int>(
+        valueListenable: _navBarIndex,
+        builder: (context, value, child) {
+          return AnimatedContainer(
+            duration: Duration(milliseconds: 300),
+            height: value == 1 ? 84.0 : 0,
+            child: (value == 1)
+                ? CustomNavBar(
+                    currentIndex: value,
+                    onTap: (index) {
+                      if (index == 0 || index == 3) {
+                        // Navigation logic
+                      } else {
+                        _pageController.jumpToPage(index - 1);
+                      }
+                    },
+                  )
+                : Container(),
+          );
+        },
+      ),
+    );
   }
 
   Future<void> setThemeNotifier(ThemeNotifier themeNotifier) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,7 +155,8 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  ValueNotifier<int> _navBarIndex = ValueNotifier<int>(1);
+  final ValueNotifier<int> _navBarIndex = ValueNotifier<int>(1);
+  ValueNotifier<double> _navBarHeight = ValueNotifier<double>(80.0);
   late PageController _pageController;
   late ThemeNotifier themeNotifier;
   late HapticNotifier hapticNotifier;
@@ -169,8 +170,12 @@ class _MyHomePageState extends State<MyHomePage> {
     widget.service.initalizeHapticSetting();
     widget.service.initalizeSoundSetting();
 
-    _pageController = PageController(
-        initialPage: _navBarIndex.value - 1); // Adjust the initialPage
+    _pageController = PageController(initialPage: _navBarIndex.value - 1);
+    _pageController.addListener(() {
+      double percentage = _pageController.page!;
+      _navBarHeight.value = (1 - percentage) * 80.0;
+    });
+
     themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
     hapticNotifier = Provider.of<HapticNotifier>(context, listen: false);
     soundNotifier = Provider.of<SoundNotifer>(context, listen: false);
@@ -214,24 +219,22 @@ class _MyHomePageState extends State<MyHomePage> {
         },
         children: pages,
       ),
-      bottomNavigationBar: ValueListenableBuilder<int>(
-        valueListenable: _navBarIndex,
+      bottomNavigationBar: ValueListenableBuilder<double>(
+        valueListenable: _navBarHeight,
         builder: (context, value, child) {
           return AnimatedContainer(
-            duration: Duration(milliseconds: 300),
-            height: value == 1 ? 84.0 : 0,
-            child: (value == 1)
-                ? CustomNavBar(
-                    currentIndex: value,
-                    onTap: (index) {
-                      if (index == 0 || index == 3) {
-                        // Navigation logic
-                      } else {
-                        _pageController.jumpToPage(index - 1);
-                      }
-                    },
-                  )
-                : Container(),
+            duration: Duration(milliseconds: 100), // Smoother animation
+            height: value,
+            child: CustomNavBar(
+              currentIndex: _navBarIndex.value,
+              onTap: (index) {
+                if (index == 0 || index == 3) {
+                  // Navigation logic
+                } else {
+                  _pageController.jumpToPage(index - 1);
+                }
+              },
+            ),
           );
         },
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -228,7 +228,17 @@ class _MyHomePageState extends State<MyHomePage> {
               currentIndex: _navBarIndex.value,
               onTap: (index) {
                 if (index == 0 || index == 3) {
-                  // Navigation logic
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => index == 0
+                            ? StatsPage(service: widget.service)
+                            : SettingsPage(
+                                service: widget.service,
+                                themeNotifier: themeNotifier,
+                                hapticNotifier: hapticNotifier,
+                                soundNotifier: soundNotifier)),
+                  );
                 } else {
                   _pageController.animateToPage(index - 1,
                       duration: Duration(milliseconds: 750),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -53,6 +53,7 @@ class _HomePageState extends State<HomePage>
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Scaffold(
       appBar: CustomAppBar(
         onAddTaskPressed: _createTaskButton,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -592,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  page_transition:
+    dependency: "direct main"
+    description:
+      name: page_transition
+      sha256: a7694bc120b7064a7f57c336914bb8885acf4f70bb3772c30c2fcfe6a85e43ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.9"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   progress_border: ^0.1.2
   number_precision: ^2.0.2+1
   flutter_native_splash: ^2.3.2
+  page_transition: ^2.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Don't make `main` and all subsequent widgets rebuild when changing pages
- make nav bar animation proportional to amount swiped
- use `PageTransitions` package to control settings/stats page routes